### PR TITLE
Update github project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author='Madis Väin',
     author_email='madis@namespace.ee',
-    url='https://github.com/namespace-ou/django-drip-marketing',
+    url='https://github.com/namespace-ee/django-drip-marketing',
     packages=[
         'drip_marketing',
     ],


### PR DESCRIPTION
s/namespace-ou/namespace-ee/

It's only a tiny change, but currently the link from PyPI to the source repository is broken without it.

Thanks for sharing your code!